### PR TITLE
Linking en Table Rows

### DIFF
--- a/components/table.tsx
+++ b/components/table.tsx
@@ -5,9 +5,10 @@ type TableProps<T> = {
     title: string,
     headerItems: string[],
     rowItems: T[],
+    linkTo?: string,
 }
 
-export default function Table<T>({ title, headerItems, rowItems }: TableProps<T>) {
+export default function Table<T>({ title, headerItems, rowItems, linkTo }: TableProps<T>) {
     return (
     <div className="container max-w-7xl mx-auto mt-8">
         <div className="mb-4">
@@ -27,7 +28,7 @@ export default function Table<T>({ title, headerItems, rowItems }: TableProps<T>
 
                         <tbody>
                         {rowItems.map((item, index) => (
-                            <TableRow key={index} item={item} items={headerItems} />
+                            <TableRow linkTo={linkTo} key={index} item={item} items={headerItems} />
                         ))}
                         </tbody>
                     </table>

--- a/components/tableRow.tsx
+++ b/components/tableRow.tsx
@@ -1,17 +1,22 @@
-type TableRowProps<T> = {
-    item: T,
-    items: string[],
-}
+    import { useRouter } from 'next/router'
 
-export default function TableRow<T>({ item, items }: TableRowProps<T>) {
-    // item is the current row you're mapping, items is the list of columns so it can be generic.
-    return (
-        <tr key={`${item["id"]}`}>
-            {items.map((column, index) => (
-                <td key={index} className="px-6 py-4 whitespace-no-wrap border-b border-gray-200">
-                    <div className="flex items-center">{item[column]}</div>
-                </td>
-            ))}
-        </tr>
-    )
-}
+    type TableRowProps<T> = {
+        item: T,
+        items: string[],
+        linkTo?: string,
+    }
+
+    export default function TableRow<T>({ item, items, linkTo }: TableRowProps<T>) {
+        const router = useRouter()
+
+        // item is the current row you're mapping, items is the list of columns so it can be generic.
+        return (
+            <tr key={`${item["id"]}`} style={linkTo ? { cursor: 'pointer' } : {}} onClick={() => router.push(`${linkTo}/${item["id"]}`)}>
+                {items.map((column, index) => (
+                    <td key={index} className="px-6 py-4 whitespace-no-wrap border-b border-gray-200">
+                        <div className="flex items-center">{item[column]}</div>
+                    </td>
+                ))}
+            </tr>
+        )
+    }

--- a/pages/proyectos/index.tsx
+++ b/pages/proyectos/index.tsx
@@ -27,6 +27,7 @@ export default function Projects() {
                 title="Proyectos" 
                 headerItems={["id", "nombre", "estado", "cliente"]}
                 rowItems={projects}
+                linkTo="/proyectos"
                 />
         </>
     )


### PR DESCRIPTION
Agrega que las filas de una Table puedan ser clickeables. Si o si las rows tienen que tener ID para que usen el parametro linkTo, ya que redirecciona a linkTo/{id}.